### PR TITLE
Fix GetLayoutClip when it has Margin

### DIFF
--- a/src/Runtime/Runtime/System.Windows/FrameworkElement.Layout.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement.Layout.cs
@@ -392,7 +392,7 @@ namespace Windows.UI.Xaml
 
                 if (needToClipSlot)
                 {
-                    Point offset = VisualOffset;
+                    Point offset = ComputeAlignmentOffset(clippingSize, inkSize);
 
                     double left, top, width, height;
                     if (offset.X < 0)


### PR DESCRIPTION
It can reproduce the issue with the following xaml.
`    <StackPanel>
        <Grid Background="Gray" Width="18">
            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="6" >
                <ContentPresenter Width="38">
                    <TextBlock Text="X" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="18"/>
                </ContentPresenter>
            </StackPanel>
        </Grid>
    </StackPanel>`